### PR TITLE
fix: asChild prop is not working (Slot can have only 1 child)

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Slot } from "@radix-ui/react-slot";
+import { Slot, Slottable } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
@@ -87,19 +87,17 @@ const Button = React.forwardRef<
         ref={ref}
         {...props}
       >
-        <React.Fragment>
           {Icon && iconPlacement === "left" && (
             <div className="w-0 translate-x-[0%] pr-0 opacity-0 transition-all duration-200 group-hover:w-5 group-hover:translate-x-100 group-hover:pr-2 group-hover:opacity-100">
               <Icon />
             </div>
           )}
-          {props.children}
+          <Slottable>{props.children}</Slottable>
           {Icon && iconPlacement === "right" && (
             <div className="w-0 translate-x-[100%] pl-0 opacity-0 transition-all duration-200 group-hover:w-5 group-hover:translate-x-0 group-hover:pl-2 group-hover:opacity-100">
               <Icon />
             </div>
           )}
-        </React.Fragment>
       </Comp>
     );
   }


### PR DESCRIPTION
PR https://github.com/jakobhoeg/enhanced-button/pull/4 attempted to solve the issue https://github.com/jakobhoeg/enhanced-button/issues/3 by adding `React.Fragment`, but as [the author himself pointed out](https://github.com/jakobhoeg/enhanced-button/issues/3#issuecomment-1932344039), this solution doesn't work.

The [Radix UI documentation suggests](https://www.radix-ui.com/primitives/docs/utilities/slot) an alternative approach using the `Slottable` component to resolve this problem.