### PR TITLE
allow more kind of Icons to be used with the `expandIcon`

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -125,14 +125,14 @@ const tailwindCode = `const config = {
 
 const exampleButtonIconRight = `import { Button } from "./ui/button";
 
-<Button variant="expandIcon" Icon={ArrowRightIcon} iconPlacement="right">
+<Button variant="expandIcon" Icon={<ArrowRightIcon />} iconPlacement="right">
 Icon right
 </Button>`
 
 
 const exampleButtonIconLeft = `import { Button } from "./ui/button";
 
-<Button variant="expandIcon" Icon={ArrowLeftIcon} iconPlacement="left">
+<Button variant="expandIcon" Icon={<ArrowLeftIcon />} iconPlacement="left">
 Icon left
 </Button>`
 
@@ -172,4 +172,4 @@ const exampleButtonLinkHover2 = `import { Button } from "./ui/button";
 Link hover 2
 </Button>`
 
-export  {buttonCode, tailwindCode, exampleButtonIconRight, exampleButtonIconLeft, exampleButtonGooeyLeft, exampleButtonGooeyRight, exampleButtonShine, exampleButtonRingHover, exampleButtonLinkHover1, exampleButtonLinkHover2}
+export { buttonCode, exampleButtonGooeyLeft, exampleButtonGooeyRight, exampleButtonIconLeft, exampleButtonIconRight, exampleButtonLinkHover1, exampleButtonLinkHover2, exampleButtonRingHover, exampleButtonShine, tailwindCode };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
+import { cn } from "@/lib/utils";
 import { Slot, Slottable } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "@/lib/utils";
+import * as React from "react";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
@@ -47,7 +47,7 @@ const buttonVariants = cva(
 );
 
 interface IconProps {
-  Icon: React.ElementType;
+  Icon: React.ReactNode;
   iconPlacement: "left" | "right";
 }
 
@@ -89,13 +89,13 @@ const Button = React.forwardRef<
       >
         {Icon && iconPlacement === "left" && (
           <div className="w-0 translate-x-[0%] pr-0 opacity-0 transition-all duration-200 group-hover:w-5 group-hover:translate-x-100 group-hover:pr-2 group-hover:opacity-100">
-            <Icon />
+           {Icon}
           </div>
         )}
         <Slottable>{props.children}</Slottable>
         {Icon && iconPlacement === "right" && (
           <div className="w-0 translate-x-[100%] pl-0 opacity-0 transition-all duration-200 group-hover:w-5 group-hover:translate-x-0 group-hover:pl-2 group-hover:opacity-100">
-            <Icon />
+            {Icon}
           </div>
         )}
       </Comp>


### PR DESCRIPTION
As mentioned in #7 I wanted to allow for more Icons and Icon Variants from different libraries to be used.
These changes allow to pass a Icon like this
![image](https://github.com/jakobhoeg/enhanced-button/assets/58025175/f4e053e4-6892-4f2c-9709-658a8b2c5e8b)