### PR TITLE
Update README.md left variant goes far right

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps & ButtonIconProps
         {Icon &&
           iconPlacement === 'left' &&
           (effect === 'expandIcon' ? (
-            <div className="w-0 translate-x-[0%] pr-0 opacity-0 transition-all duration-200 group-hover:w-5 group-hover:translate-x-100 group-hover:pr-2 group-hover:opacity-100">
+            <div className="w-0 translate-x-[0%] pr-0 opacity-0 transition-all duration-200 group-hover:w-5 group-hover:translate-x-0 group-hover:pr-2 group-hover:opacity-100">
               <Icon />
             </div>
           ) : (


### PR DESCRIPTION
Hi bro,

From the `installation` section I changed the `translate-x-[]` property to be 0 instead of 100 on the left variant. I am using the left variant to show a Back to Home button but the icon appear on the far right.

Before:
![image](https://github.com/user-attachments/assets/8827c671-51aa-41ef-9ca9-c4c207a0a1ea)

After:
![image](https://github.com/user-attachments/assets/c93aeaa7-e86a-4acc-87e1-6876e97f8451)

Hope this helps :)